### PR TITLE
#15 支店間の本の移動をバックエンドで扱う

### DIFF
--- a/bookman/domain/repository.py
+++ b/bookman/domain/repository.py
@@ -1,0 +1,50 @@
+from django.utils import timezone
+
+from bookman.models import Book, Branch, BranchBookStock
+
+
+class BranchBookStockRepository:
+    """
+    支店別所蔵数の永続化操作。
+    """
+
+    def get_for_update(self, book: Book, branch: Branch) -> BranchBookStock | None:
+        """
+        更新対象の支店別所蔵数を行ロック付きで取得する。
+        """
+        try:
+            return BranchBookStock.objects.select_for_update().get(
+                book=book,
+                branch=branch,
+            )
+        except BranchBookStock.DoesNotExist:
+            return None
+
+    def get_or_create_for_update(
+        self, book: Book, branch: Branch
+    ) -> tuple[BranchBookStock, bool]:
+        """
+        更新対象の支店別所蔵数を行ロック付きで取得し、存在しない場合は作成する。
+        """
+        return BranchBookStock.objects.select_for_update().get_or_create(
+            book=book,
+            branch=branch,
+            defaults={"amount": 0},
+        )
+
+    def save(self, stock: BranchBookStock) -> None:
+        """
+        支店別所蔵数を保存する。
+        """
+        stock.updated_at = timezone.localdate()
+        stock.save(update_fields=["amount", "updated_at"])
+
+    def bulk_save(self, stocks: list[BranchBookStock]) -> None:
+        """
+        複数の支店別所蔵数をまとめて保存する。
+        """
+        updated_at = timezone.localdate()
+        for stock in stocks:
+            stock.updated_at = updated_at
+
+        BranchBookStock.objects.bulk_update(stocks, ["amount", "updated_at"])

--- a/bookman/domain/service.py
+++ b/bookman/domain/service.py
@@ -1,9 +1,8 @@
-from dataclasses import dataclass
-
 from django.db import transaction
 
 from bookman.domain.repository import BranchBookStockRepository
-from bookman.models import Book, Branch, BranchBookStock
+from bookman.domain.valueobject import BranchBookStockTransfer
+from bookman.models import Book, Branch
 
 
 class BranchBookStockTransferError(Exception):
@@ -22,28 +21,6 @@ class InsufficientStockError(BranchBookStockTransferError):
     """
     移動元支店の所蔵数が移動冊数に満たない場合の例外。
     """
-
-
-@dataclass(frozen=True)
-class BranchBookStockTransfer:
-    """
-    支店間移動後の所蔵状態。
-
-    Attributes:
-        book: 移動対象の書籍。
-        from_branch: 移動元支店。
-        to_branch: 移動先支店。
-        amount: 移動した冊数。
-        source_stock: 移動後の移動元支店別所蔵数。
-        destination_stock: 移動後の移動先支店別所蔵数。
-    """
-
-    book: Book
-    from_branch: Branch
-    to_branch: Branch
-    amount: int
-    source_stock: BranchBookStock
-    destination_stock: BranchBookStock
 
 
 class BranchBookStockTransferService:

--- a/bookman/domain/service.py
+++ b/bookman/domain/service.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from bookman.domain.repository import BranchBookStockRepository
+from bookman.models import Book, Branch, BranchBookStock
+
+
+class BranchBookStockTransferError(Exception):
+    """
+    支店間移動が業務ルール上実行できない場合の例外。
+    """
+
+
+class SourceStockNotFoundError(BranchBookStockTransferError):
+    """
+    移動元支店に対象書籍の所蔵がない場合の例外。
+    """
+
+
+class InsufficientStockError(BranchBookStockTransferError):
+    """
+    移動元支店の所蔵数が移動冊数に満たない場合の例外。
+    """
+
+
+@dataclass(frozen=True)
+class BranchBookStockTransfer:
+    """
+    支店間移動後の所蔵状態。
+
+    Attributes:
+        book: 移動対象の書籍。
+        from_branch: 移動元支店。
+        to_branch: 移動先支店。
+        amount: 移動した冊数。
+        source_stock: 移動後の移動元支店別所蔵数。
+        destination_stock: 移動後の移動先支店別所蔵数。
+    """
+
+    book: Book
+    from_branch: Branch
+    to_branch: Branch
+    amount: int
+    source_stock: BranchBookStock
+    destination_stock: BranchBookStock
+
+
+class BranchBookStockTransferService:
+    """
+    支店間で本を移動する業務処理。
+    """
+
+    def __init__(self, repository: BranchBookStockRepository | None = None):
+        self.repository = repository or BranchBookStockRepository()
+
+    def transfer(
+        self,
+        *,
+        book: Book,
+        from_branch: Branch,
+        to_branch: Branch,
+        amount: int,
+    ) -> BranchBookStockTransfer:
+        """
+        移動元の所蔵数を減らし、移動先の所蔵数を増やす。
+        """
+        with transaction.atomic():
+            source_stock = self.repository.get_for_update(book, from_branch)
+            if source_stock is None:
+                raise SourceStockNotFoundError
+
+            if source_stock.amount < amount:
+                raise InsufficientStockError
+
+            destination_stock, created = self.repository.get_or_create_for_update(
+                book,
+                to_branch,
+            )
+
+            source_stock.amount -= amount
+            destination_stock.amount += amount
+
+            if created:
+                self.repository.save(source_stock)
+                self.repository.save(destination_stock)
+            else:
+                self.repository.bulk_save([source_stock, destination_stock])
+
+        return BranchBookStockTransfer(
+            book=book,
+            from_branch=from_branch,
+            to_branch=to_branch,
+            amount=amount,
+            source_stock=source_stock,
+            destination_stock=destination_stock,
+        )

--- a/bookman/domain/valueobject.py
+++ b/bookman/domain/valueobject.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+from bookman.models import Book, Branch, BranchBookStock
+
+
+@dataclass(frozen=True)
+class BranchBookStockTransfer:
+    """
+    支店間移動後の所蔵状態。
+
+    Attributes:
+        book: 移動対象の書籍。
+        from_branch: 移動元支店。
+        to_branch: 移動先支店。
+        amount: 移動した冊数。
+        source_stock: 移動後の移動元支店別所蔵数。
+        destination_stock: 移動後の移動先支店別所蔵数。
+    """
+
+    book: Book
+    from_branch: Branch
+    to_branch: Branch
+    amount: int
+    source_stock: BranchBookStock
+    destination_stock: BranchBookStock

--- a/bookman/serializers.py
+++ b/bookman/serializers.py
@@ -7,6 +7,11 @@ API リクエストでは JSON の入力値を検証して model に保存でき
 
 from rest_framework import serializers
 
+from bookman.domain.service import (
+    BranchBookStockTransferService,
+    InsufficientStockError,
+    SourceStockNotFoundError,
+)
 from bookman.models import Author, Book, Branch, BranchBookStock, Category
 
 
@@ -56,6 +61,51 @@ class BranchBookStockSerializer(serializers.ModelSerializer):
     class Meta:
         model = BranchBookStock
         fields = ["id", "branch", "branch_name", "book", "book_name", "amount"]
+
+
+class BranchBookStockTransferSerializer(serializers.Serializer):
+    """
+    支店間の本の移動APIの入出力。
+
+    1リクエストで移動元の所蔵数を減らし、移動先の所蔵数を増やす。
+    """
+
+    book = serializers.PrimaryKeyRelatedField(queryset=Book.objects.order_by("id"))
+    from_branch = serializers.PrimaryKeyRelatedField(
+        queryset=Branch.objects.order_by("id")
+    )
+    to_branch = serializers.PrimaryKeyRelatedField(
+        queryset=Branch.objects.order_by("id")
+    )
+    amount = serializers.IntegerField(min_value=1)
+    source_stock = BranchBookStockSerializer(read_only=True)
+    destination_stock = BranchBookStockSerializer(read_only=True)
+
+    def validate(self, attrs):
+        """
+        同一支店への移動を拒否する。
+        """
+        if attrs["from_branch"] == attrs["to_branch"]:
+            raise serializers.ValidationError(
+                {"to_branch": "移動元と移動先には別の支店を指定してください。"}
+            )
+
+        return attrs
+
+    def create(self, validated_data):
+        """
+        支店間移動の業務処理を実行する。
+        """
+        try:
+            return BranchBookStockTransferService().transfer(**validated_data)
+        except SourceStockNotFoundError as exc:
+            raise serializers.ValidationError(
+                {"from_branch": "移動元支店に対象書籍の所蔵がありません。"}
+            ) from exc
+        except InsufficientStockError as exc:
+            raise serializers.ValidationError(
+                {"amount": "移動元支店の所蔵数が不足しています。"}
+            ) from exc
 
 
 class BookSerializer(serializers.ModelSerializer):

--- a/bookman/tests.py
+++ b/bookman/tests.py
@@ -238,6 +238,171 @@ class BookmanApiTest(APITestCase):
         self.branch_stock.refresh_from_db()
         self.assertEqual(self.branch_stock.amount, 3)
 
+    def test_branch_book_stock_transfer_creates_destination_stock(self):
+        """
+        シナリオ:
+        - 入力: 移動元に2冊あり、移動先には対象書籍の所蔵行がない状態。
+        - 処理: 支店間移動APIへ1冊の移動リクエストをPOSTする。
+        - 期待値: 移動元が1冊減り、移動先の所蔵行が1冊で作成されること。
+        """
+        payload = {
+            "book": self.book.id,
+            "from_branch": self.branch.id,
+            "to_branch": self.second_branch.id,
+            "amount": 1,
+        }
+
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/", payload, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.branch_stock.refresh_from_db()
+        destination_stock = BranchBookStock.objects.get(
+            book=self.book, branch=self.second_branch
+        )
+        self.assertEqual(self.branch_stock.amount, 1)
+        self.assertEqual(destination_stock.amount, 1)
+        self.assertEqual(response.data["source_stock"]["amount"], 1)
+        self.assertEqual(response.data["destination_stock"]["amount"], 1)
+
+    def test_branch_book_stock_transfer_adds_existing_destination_stock(self):
+        """
+        シナリオ:
+        - 入力: 移動元に2冊、移動先に同じ書籍が4冊ある状態。
+        - 処理: 支店間移動APIへ2冊の移動リクエストをPOSTする。
+        - 期待値: 移動元が0冊、移動先が6冊になり、書籍全体の所蔵数は変わらないこと。
+        """
+        destination_stock = BranchBookStock.objects.create(
+            branch=self.second_branch,
+            book=self.book,
+            amount=4,
+        )
+
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/",
+            {
+                "book": self.book.id,
+                "from_branch": self.branch.id,
+                "to_branch": self.second_branch.id,
+                "amount": 2,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.branch_stock.refresh_from_db()
+        destination_stock.refresh_from_db()
+        detail_response = self.client.get(f"/bookman/api/books/{self.book.id}/")
+        self.assertEqual(self.branch_stock.amount, 0)
+        self.assertEqual(destination_stock.amount, 6)
+        self.assertEqual(detail_response.data["total_amount"], 6)
+
+    def test_branch_book_stock_transfer_rejects_same_branch(self):
+        """
+        シナリオ:
+        - 入力: 移動元と移動先に同じ支店を指定した移動ペイロード。
+        - 処理: 支店間移動APIへPOSTリクエストする。
+        - 期待値: 400 が返り、所蔵数が変更されないこと。
+        """
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/",
+            {
+                "book": self.book.id,
+                "from_branch": self.branch.id,
+                "to_branch": self.branch.id,
+                "amount": 1,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.branch_stock.refresh_from_db()
+        self.assertEqual(self.branch_stock.amount, 2)
+
+    def test_branch_book_stock_transfer_rejects_zero_amount(self):
+        """
+        シナリオ:
+        - 入力: 移動冊数に0を指定した移動ペイロード。
+        - 処理: 支店間移動APIへPOSTリクエストする。
+        - 期待値: 400 が返り、所蔵数が変更されないこと。
+        """
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/",
+            {
+                "book": self.book.id,
+                "from_branch": self.branch.id,
+                "to_branch": self.second_branch.id,
+                "amount": 0,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.branch_stock.refresh_from_db()
+        self.assertEqual(self.branch_stock.amount, 2)
+
+    def test_branch_book_stock_transfer_rejects_insufficient_stock(self):
+        """
+        シナリオ:
+        - 入力: 移動元の所蔵数2冊を超える3冊の移動ペイロード。
+        - 処理: 支店間移動APIへPOSTリクエストする。
+        - 期待値: 400 が返り、移動先の所蔵行が作成されないこと。
+        """
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/",
+            {
+                "book": self.book.id,
+                "from_branch": self.branch.id,
+                "to_branch": self.second_branch.id,
+                "amount": 3,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.branch_stock.refresh_from_db()
+        self.assertEqual(self.branch_stock.amount, 2)
+        self.assertFalse(
+            BranchBookStock.objects.filter(
+                book=self.book, branch=self.second_branch
+            ).exists()
+        )
+
+    def test_branch_book_stock_transfer_rejects_missing_source_stock(self):
+        """
+        シナリオ:
+        - 入力: 移動元に対象書籍の所蔵行がない移動ペイロード。
+        - 処理: 支店間移動APIへPOSTリクエストする。
+        - 期待値: 400 が返り、移動先の所蔵行が作成されないこと。
+        """
+        other_book = Book.objects.create(
+            name="こころ",
+            category=self.category,
+            lead_text="近代文学です。",
+            isbn="9780000000003",
+            publication_date=date(2026, 1, 3),
+        )
+        other_book.authors.set([self.author])
+
+        response = self.client.post(
+            "/bookman/api/branch-book-stocks/transfer/",
+            {
+                "book": other_book.id,
+                "from_branch": self.branch.id,
+                "to_branch": self.second_branch.id,
+                "amount": 1,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            BranchBookStock.objects.filter(
+                book=other_book, branch=self.second_branch
+            ).exists()
+        )
+
     def test_lending_belongs_to_branch_book_stock(self):
         """
         シナリオ:

--- a/bookman/urls.py
+++ b/bookman/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
         views.BranchBookStockDetail.as_view(),
         name="branch_book_stock_detail",
     ),
+    path(
+        "api/branch-book-stocks/transfer/",
+        views.BranchBookStockTransfer.as_view(),
+        name="branch_book_stock_transfer",
+    ),
     path("api/authors/", views.AuthorList.as_view(), name="author_list"),
     path("api/categories/", views.CategoryList.as_view(), name="category_list"),
 ]

--- a/bookman/views.py
+++ b/bookman/views.py
@@ -1,10 +1,12 @@
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
-from rest_framework import generics
+from rest_framework import generics, status
+from rest_framework.response import Response
 
 from .models import Author, Book, Branch, BranchBookStock, Category
 from .serializers import (
     AuthorSerializer,
+    BranchBookStockTransferSerializer,
     BranchBookStockSerializer,
     BookSerializer,
     BranchSerializer,
@@ -85,3 +87,16 @@ class BranchBookStockDetail(generics.RetrieveUpdateAPIView):
 
     def get_queryset(self):
         return BranchBookStock.objects.select_related("branch", "book")
+
+
+class BranchBookStockTransfer(generics.GenericAPIView):
+    serializer_class = BranchBookStockTransferSerializer
+
+    def post(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        transfer = serializer.save()
+        return Response(
+            self.get_serializer(transfer).data,
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Summary
支店別所蔵数の直接更新 API を前提に、支店間の本の移動を1リクエストで扱うバックエンド API を追加しました。

- `POST /bookman/api/branch-book-stocks/transfer/` を追加
- 移動処理を `domain` 配下の repository/service/valueobject に分離
- トランザクション内で移動元減算・移動先加算を実行
- 移動先所蔵行がない場合の作成、同一支店・0冊・不足・移動元なしのエラーを API テストで追加

## 目検による動作確認手順
- [x] 今回はバックエンド API の挙動追加のみで、画面表示や外部連携の目検対象はなし。
- [x] 支店間移動の正常系・異常系・合計所蔵数への影響は `python manage.py test bookman` の API テストでカバー済みのため、PR本文で長いPowerShell確認コマンドは再実装しない。

## 自動テストでカバーできた範囲
- `python -m black --check bookman\domain\service.py bookman\domain\valueobject.py`
  - Value Object 分離後のフォーマットを確認
- `git diff --check`
  - 空白エラーがないことを確認
- `python manage.py test bookman`
  - bookman アプリの API テスト 17 件が成功
  - 支店間移動 API のカバー範囲:
    - 移動先所蔵行がない場合に作成されること
    - 既存移動先へ加算されること
    - 同一支店への移動が 400 で拒否され、所蔵数が変わらないこと
    - 0冊移動が 400 で拒否され、所蔵数が変わらないこと
    - 移動元所蔵数を超える移動が 400 で拒否され、移動先行が作成されないこと
    - 移動元に対象書籍の所蔵行がない場合に 400 で拒否されること
    - 書籍詳細の `total_amount` が支店別所蔵数から算出されること

## 関連Issue
Closes #15
https://github.com/duri0214/bookman_backend/issues/15
