### PR TITLE
#28 貸出・返却APIの業務エラーレスポンスを整理する

### DIFF
--- a/bookman/exceptions.py
+++ b/bookman/exceptions.py
@@ -1,0 +1,18 @@
+class BusinessRuleApiError(Exception):
+    """
+    業務ルール違反を固定形式のAPIエラーレスポンスに変換するための例外。
+    """
+
+    status_code = 400
+
+    def __init__(self, *, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+    def to_response_data(self):
+        return {
+            "code": self.code,
+            "message": self.message,
+            "status_code": self.status_code,
+        }

--- a/bookman/serializers.py
+++ b/bookman/serializers.py
@@ -7,6 +7,7 @@ API リクエストでは JSON の入力値を検証して model に保存でき
 
 from rest_framework import serializers
 
+from bookman.exceptions import BusinessRuleApiError
 from bookman.domain.service import (
     BranchBookStockTransferService,
     CustomerLendingLimitExceededError,
@@ -177,16 +178,19 @@ class LendingSerializer(serializers.ModelSerializer):
         try:
             return LendingService().lend(**validated_data)
         except DuplicateBookLendingError as exc:
-            raise serializers.ValidationError(
-                {"customer": "同じ利用者は同じ本を2冊以上借りられません。"}
+            raise BusinessRuleApiError(
+                code="duplicate_book_lending",
+                message="同じ利用者は同じ本を2冊以上借りられません。",
             ) from exc
         except LendingStockUnavailableError as exc:
-            raise serializers.ValidationError(
-                {"branch_book_stock": "対象の本は貸出可能冊数が残っていません。"}
+            raise BusinessRuleApiError(
+                code="lending_stock_unavailable",
+                message="対象の本は貸出可能冊数が残っていません。",
             ) from exc
         except CustomerLendingLimitExceededError as exc:
-            raise serializers.ValidationError(
-                {"customer": "利用者の貸出上限冊数に達しています。"}
+            raise BusinessRuleApiError(
+                code="customer_lending_limit_exceeded",
+                message="利用者の貸出上限冊数に達しています。",
             ) from exc
 
 
@@ -207,12 +211,14 @@ class LendingReturnSerializer(serializers.Serializer):
         try:
             return LendingService().return_lending(lending_id=validated_data["lending"])
         except LendingNotFoundError as exc:
-            raise serializers.ValidationError(
-                {"lending": "返却対象の貸出情報が見つかりません。"}
+            raise BusinessRuleApiError(
+                code="lending_not_found",
+                message="返却対象の貸出情報が見つかりません。",
             ) from exc
         except LendingAlreadyReturnedError as exc:
-            raise serializers.ValidationError(
-                {"lending": "返却対象の貸出情報はすでに返却済みです。"}
+            raise BusinessRuleApiError(
+                code="lending_already_returned",
+                message="返却対象の貸出情報はすでに返却済みです。",
             ) from exc
 
     def to_representation(self, instance):

--- a/bookman/tests.py
+++ b/bookman/tests.py
@@ -60,6 +60,17 @@ class BookmanApiTest(APITestCase):
             amount=2,
         )
 
+    def assert_business_error_response(self, response, *, code, message):
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "code": code,
+                "message": message,
+                "status_code": status.HTTP_400_BAD_REQUEST,
+            },
+        )
+
     def test_branch_list_returns_frontend_fields(self):
         """
         シナリオ:
@@ -494,7 +505,7 @@ class BookmanApiTest(APITestCase):
         シナリオ:
         - 入力: 利用者が同じ本をすでに貸出中の状態。
         - 処理: 同じ支店別所蔵に対して貸出APIへPOSTする。
-        - 期待値: 400 が返り、同じ利用者に2件目の貸出が作成されないこと。
+        - 期待値: 重複貸出コード付きの400が返り、同じ利用者に2件目の貸出が作成されないこと。
         """
         Lending.objects.create(
             branch_book_stock=self.branch_stock,
@@ -514,7 +525,11 @@ class BookmanApiTest(APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assert_business_error_response(
+            response,
+            code="duplicate_book_lending",
+            message="同じ利用者は同じ本を2冊以上借りられません。",
+        )
         self.assertEqual(
             Lending.objects.filter(customer=self.customer, active=True).count(),
             1,
@@ -525,7 +540,7 @@ class BookmanApiTest(APITestCase):
         シナリオ:
         - 入力: 支店別所蔵数2冊がすべて別利用者へ貸出中の状態。
         - 処理: さらに別利用者で貸出APIへPOSTする。
-        - 期待値: 400 が返り、在庫数を超える貸出が作成されないこと。
+        - 期待値: 在庫不足コード付きの400が返り、在庫数を超える貸出が作成されないこと。
         """
         third_customer = Customer.objects.create(name="田中次郎")
         for index in range(2):
@@ -547,7 +562,11 @@ class BookmanApiTest(APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assert_business_error_response(
+            response,
+            code="lending_stock_unavailable",
+            message="対象の本は貸出可能冊数が残っていません。",
+        )
         self.assertEqual(
             Lending.objects.filter(branch_book_stock=self.branch_stock).count(),
             2,
@@ -558,7 +577,7 @@ class BookmanApiTest(APITestCase):
         シナリオ:
         - 入力: 利用者の貸出上限2冊に達している状態。
         - 処理: 別の本で貸出APIへPOSTする。
-        - 期待値: 400 が返り、上限を超える貸出が作成されないこと。
+        - 期待値: 貸出上限超過コード付きの400が返り、上限を超える貸出が作成されないこと。
         """
         second_book = Book.objects.create(
             name="銀河鉄道の夜",
@@ -605,7 +624,11 @@ class BookmanApiTest(APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assert_business_error_response(
+            response,
+            code="customer_lending_limit_exceeded",
+            message="利用者の貸出上限冊数に達しています。",
+        )
         self.assertEqual(
             Lending.objects.filter(customer=self.customer, active=True).count(),
             2,
@@ -641,7 +664,7 @@ class BookmanApiTest(APITestCase):
         シナリオ:
         - 入力: 返却済みの貸出情報が1件ある状態。
         - 処理: 返却APIへ同じ貸出IDをPOSTする。
-        - 期待値: 400 が返り、返却済み状態のまま変わらないこと。
+        - 期待値: 返却済みコード付きの400が返り、返却済み状態のまま変わらないこと。
         """
         lending = Lending.objects.create(
             branch_book_stock=self.branch_stock,
@@ -657,9 +680,32 @@ class BookmanApiTest(APITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assert_business_error_response(
+            response,
+            code="lending_already_returned",
+            message="返却対象の貸出情報はすでに返却済みです。",
+        )
         lending.refresh_from_db()
         self.assertFalse(lending.active)
+
+    def test_lending_return_rejects_missing_lending(self):
+        """
+        シナリオ:
+        - 入力: 存在しない貸出IDを指定した返却ペイロード。
+        - 処理: 返却APIへPOSTリクエストする。
+        - 期待値: 貸出未存在コード付きの400が返ること。
+        """
+        response = self.client.post(
+            "/bookman/api/lendings/return/",
+            {"lending": 999999},
+            format="json",
+        )
+
+        self.assert_business_error_response(
+            response,
+            code="lending_not_found",
+            message="返却対象の貸出情報が見つかりません。",
+        )
 
     def test_author_and_category_lists_are_ordered_by_id(self):
         """

--- a/bookman/views.py
+++ b/bookman/views.py
@@ -3,6 +3,7 @@ from django.db.models.functions import Coalesce
 from rest_framework import generics, status
 from rest_framework.response import Response
 
+from .exceptions import BusinessRuleApiError
 from .models import Author, Book, Branch, BranchBookStock, Category, Customer, Lending
 from .serializers import (
     AuthorSerializer,
@@ -123,6 +124,19 @@ class LendingList(generics.ListCreateAPIView):
             "contact_user",
         ).order_by("-id")
 
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            lending = serializer.save()
+        except BusinessRuleApiError as exc:
+            return Response(exc.to_response_data(), status=exc.status_code)
+
+        return Response(
+            self.get_serializer(lending).data,
+            status=status.HTTP_201_CREATED,
+        )
+
 
 class LendingReturn(generics.GenericAPIView):
     serializer_class = LendingReturnSerializer
@@ -130,7 +144,11 @@ class LendingReturn(generics.GenericAPIView):
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        result = serializer.save()
+        try:
+            result = serializer.save()
+        except BusinessRuleApiError as exc:
+            return Response(exc.to_response_data(), status=exc.status_code)
+
         return Response(
             self.get_serializer(result).data,
             status=status.HTTP_200_OK,


### PR DESCRIPTION
## Summary
貸出・返却APIの業務エラーを、フロントエンドが機械的に判定できる固定レスポンスへ整理しました。

- `BusinessRuleApiError` を追加し、貸出・返却APIの view 内で業務エラーだけ `{code, message, status_code}` 形式へ変換
- 重複貸出、在庫不足、貸出上限超過、貸出未存在、返却済み再返却のエラーコードを固定
- `settings.py` の DRF グローバル exception handler は変更せず、通常の serializer 入力検証エラーは DRF 標準形式のまま維持
- 貸出・返却 API テストで各業務エラーの `code` / `message` / `status_code` を検証

## 目検による動作確認手順
- [x] 画面表示や外部連携の変更はなく、目検対象なし。貸出・返却APIの業務エラーレスポンス契約は自動テストでカバー済み。

## 自動テストでカバーできた範囲
- `python -m black bookman\exceptions.py bookman\views.py config\settings.py`
  - 変更した Python ファイルのフォーマットを確認
- `git diff --check`
  - 空白エラーがないことを確認
- `python manage.py test bookman --noinput`
  - bookman アプリの 25 tests OK
  - 重複貸出、在庫不足、貸出上限超過、貸出未存在、返却済み再返却の業務エラーレスポンスを確認
  - 既存の書籍、支店別所蔵、支店間移動、貸出・返却正常系 API が成功
- `python manage.py test --noinput`
  - プロジェクト全体の 25 tests OK

## 関連Issue
Closes #28
https://github.com/duri0214/bookman_backend/issues/28
