### PR TITLE
#32 支店別所蔵APIで貸出可能冊数を返す

### DIFF
--- a/bookman/serializers.py
+++ b/bookman/serializers.py
@@ -86,10 +86,29 @@ class BranchBookStockSerializer(serializers.ModelSerializer):
 
     branch_name = serializers.CharField(source="branch.name", read_only=True)
     book_name = serializers.CharField(source="book.name", read_only=True)
+    available_amount = serializers.SerializerMethodField()
 
     class Meta:
         model = BranchBookStock
-        fields = ["id", "branch", "branch_name", "book", "book_name", "amount"]
+        fields = [
+            "id",
+            "branch",
+            "branch_name",
+            "book",
+            "book_name",
+            "amount",
+            "available_amount",
+        ]
+
+    def get_available_amount(self, obj):
+        """
+        支店別所蔵数から貸出中の冊数を差し引いた貸出可能冊数を返す。
+        """
+        active_lending_count = getattr(obj, "active_lending_count", None)
+        if active_lending_count is None:
+            active_lending_count = obj.lendings.filter(active=True).count()
+
+        return max(obj.amount - active_lending_count, 0)
 
 
 class BranchBookStockTransferSerializer(serializers.Serializer):

--- a/bookman/tests.py
+++ b/bookman/tests.py
@@ -228,6 +228,27 @@ class BookmanApiTest(APITestCase):
         self.assertEqual(response.data[0]["book"], self.book.id)
         self.assertEqual(response.data[0]["book_name"], "吾輩は猫である")
         self.assertEqual(response.data[0]["amount"], 2)
+        self.assertEqual(response.data[0]["available_amount"], 2)
+
+    def test_branch_book_stock_list_returns_available_amount(self):
+        """
+        シナリオ:
+        - 入力: 支店別所蔵数2冊のうち1冊が貸出中の状態。
+        - 処理: 所蔵数一覧APIへGETリクエストする。
+        - 期待値: amount は総所蔵数2、available_amount は貸出中1冊を差し引いた1で返ること。
+        """
+        Lending.objects.create(
+            branch_book_stock=self.branch_stock,
+            customer=self.customer,
+            contact_staff=self.contact_staff,
+            return_date=date(2026, 1, 15),
+        )
+
+        response = self.client.get("/bookman/api/branch-book-stocks/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]["amount"], 2)
+        self.assertEqual(response.data[0]["available_amount"], 1)
 
     def test_branch_book_stock_create_changes_book_total_amount_without_sync(self):
         """

--- a/bookman/views.py
+++ b/bookman/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Sum
+from django.db.models import Count, Q, Sum
 from django.db.models.functions import Coalesce
 from rest_framework import generics, status
 from rest_framework.response import Response
@@ -105,8 +105,12 @@ class BranchBookStockList(generics.ListCreateAPIView):
     serializer_class = BranchBookStockSerializer
 
     def get_queryset(self):
-        return BranchBookStock.objects.select_related("branch", "book").order_by(
-            "book_id", "branch_id", "id"
+        return (
+            BranchBookStock.objects.select_related("branch", "book")
+            .annotate(
+                active_lending_count=Count("lendings", filter=Q(lendings__active=True))
+            )
+            .order_by("book_id", "branch_id", "id")
         )
 
 
@@ -114,7 +118,9 @@ class BranchBookStockDetail(generics.RetrieveUpdateAPIView):
     serializer_class = BranchBookStockSerializer
 
     def get_queryset(self):
-        return BranchBookStock.objects.select_related("branch", "book")
+        return BranchBookStock.objects.select_related("branch", "book").annotate(
+            active_lending_count=Count("lendings", filter=Q(lendings__active=True))
+        )
 
 
 class BranchBookStockTransfer(generics.GenericAPIView):


### PR DESCRIPTION
## Summary
支店別所蔵APIで、総所蔵数とは別に貸出可能冊数を返すようにしました。

- `BranchBookStockSerializer` に `available_amount` を追加
- 一覧・詳細の queryset で active な貸出数を集計し、`amount - active貸出数` を返す
- 貸出中データがある状態で `available_amount` が減るテストを追加

## 目検による動作確認手順
- [x] バックエンドを起動する
- [x] `GET /bookman/api/branch-book-stocks/` を開く
- [x] `amount` が2冊、同じ支店別所蔵の貸出中が1件ある場合、`available_amount` が1で返ること
- [x] フロントエンドの貸出画面を再読み込みし、支店別所蔵の貸出可能冊数が `available_amount` の値で表示されること

## 自動テストでカバーできた範囲
- `black bookman\views.py bookman\serializers.py bookman\tests.py`
- `python manage.py test bookman.tests.BookmanApiTest.test_branch_book_stock_list_returns_branch_book_amounts bookman.tests.BookmanApiTest.test_branch_book_stock_list_returns_available_amount --noinput`
- `python manage.py test bookman --noinput`

## 関連Issue
Closes #32
https://github.com/duri0214/bookman_backend/issues/32
