### PR TITLE
#34 LibraryStaff fixture の created_at 欠落を修正する

### DIFF
--- a/bookman/fixtures/library-staff-data.json
+++ b/bookman/fixtures/library-staff-data.json
@@ -5,7 +5,9 @@
     "fields": {
       "name": "図書館対応者",
       "branch": 1,
-      "role": "counter"
+      "role": "counter",
+      "created_at": "2026-01-01",
+      "updated_at": "2026-01-01"
     }
   }
 ]


### PR DESCRIPTION
## Summary
LibraryStaff fixture の必須日時フィールド欠落を修正します。

- `bookman/fixtures/library-staff-data.json` に `created_at` / `updated_at` を追加
- Django の raw fixture load で `auto_now_add` が補完されず `created_at` が null になる問題を解消

## 目検による動作確認手順
- [x] 開発・検証用DBで `python manage.py loaddata bookman/fixtures/library-staff-data.json` を実行する
- [x] `Installed 1 object(s) from 1 fixture(s)` と表示され、`LibraryStaff(pk=1001)` の投入で `created_at` の NOT NULL エラーが発生しないことを確認する

## 自動テストでカバーできた範囲
- `python manage.py loaddata bookman/fixtures/library-staff-data.json`
  - LibraryStaff fixture が正常にロードできることを確認
- `python manage.py test bookman --noinput`
  - bookman アプリの既存テスト 27 件が成功することを確認

## 関連Issue
Closes #34
https://github.com/duri0214/bookman_backend/issues/34
